### PR TITLE
Use set and replace for better testing

### DIFF
--- a/package_bag/tests.py
+++ b/package_bag/tests.py
@@ -99,11 +99,11 @@ class TestPackage(TestCase):
         for package in listdir(settings.DEST_DIR):
             with tarfile.open(join(settings.DEST_DIR, package), "r") as tf:
                 names = tf.getnames()
-                bag_id = package.rstrip(".tar.gz")
-                for member in [bag_id, join(bag_id, package), join(bag_id, "{}.json".format(bag_id))]:
-                    self.assertTrue(
-                        member in names,
-                        "Incorrectly structured package: {} was not found in {}".format(member, names))
+                bag_id = package.replace(".tar.gz", "")
+                expected = [bag_id, join(bag_id, package), join(bag_id, "{}.json".format(bag_id))]
+                self.assertEqual(
+                    set(expected), set(names),
+                    "Incorrectly structured package: expected {} but got {}".format(expected, names))
 
     @patch('package_bag.routines.post')
     def test_deliver_package(self, mock_post):


### PR DESCRIPTION
This improves the earlier PR which tested bag structure.
- `rstrip()` removes all instances of a set of characters from a string, thus if a bag id ended in any of of the letters `targaz`those letters were stripped too.
- I'm now comparing the list of names with another list and checking that those lists are equal (after calling `set`, which just allows for different ordering within each list). That's a stronger test because it ensures not only that the expected items are there, but also that no unexpected items are present.