### PR TITLE
Process one bag at a time

### DIFF
--- a/package_bag/routines.py
+++ b/package_bag/routines.py
@@ -44,7 +44,7 @@ class BagDiscoverer(object):
         # what does this process bags function return? - you want to return something out of the view that indicates which objects were processed
         # e.g.: "{} bags discovered".format(len(processed)), processed
         msg = "Bag discovered." if bag else "No bags were found."
-        return msg, bag_id if bag else msg
+        return (msg, bag_id) if bag else (msg, None)
 
     def discover_next_bag(self, src):
         """Looks in a given directory for compressed bags, adds to list to process"""

--- a/package_bag/routines.py
+++ b/package_bag/routines.py
@@ -21,29 +21,26 @@ class BagDiscoverer(object):
     """
 
     def run(self):
-        processed = []
-        unprocessed = self.discover_bags(settings.SRC_DIR)
-        for bag in unprocessed:
-            try:
-                bag_id = self.unpack_rename(bag, settings.TMP_DIR)
-                bag_path = join(settings.TMP_DIR, bag_id)
-                validate(bag_path)
-                bag_data = self.validate_metadata(bag_path)
-                new_bag = Bag.objects.create(
-                    original_bag_name=bag,
-                    bag_identifier=bag_id,
-                    bag_path=bag_path)
-                for key in ["Origin", "Rights-ID", "End-Date"]:
-                    setattr(new_bag, key.lower().replace("-", "_"), bag_data.get(key))
-                new_bag.save()
-                processed.append(bag_id)
-            except Exception as e:
-                remove_file_or_dir(bag_path)
-                print(e)
+        bag = self.discover_bags(settings.SRC_DIR)[0]
+        try:
+            bag_id = self.unpack_rename(bag, settings.TMP_DIR)
+            bag_path = join(settings.TMP_DIR, bag_id)
+            validate(bag_path)
+            bag_data = self.validate_metadata(bag_path)
+            new_bag = Bag.objects.create(
+                original_bag_name=bag,
+                bag_identifier=bag_id,
+                bag_path=bag_path)
+            for key in ["Origin", "Rights-ID", "End-Date"]:
+                setattr(new_bag, key.lower().replace("-", "_"), bag_data.get(key))
+            new_bag.save()
+        except Exception as e:
+            remove_file_or_dir(bag_path)
+            print(e)
         # what does this process bags function return? - you want to return something out of the view that indicates which objects were processed
         # e.g.: "{} bags discovered".format(len(processed)), processed
-        msg = "Bags discovered." if len(processed) else "No bags were found."
-        return msg, processed
+        msg = "Bags discovered." if bag else "No bags were found."
+        return msg, bag
 
     def discover_bags(self, src):
         """Looks in a given directory for compressed bags, adds to list to process"""

--- a/package_bag/routines.py
+++ b/package_bag/routines.py
@@ -49,7 +49,7 @@ class BagDiscoverer(object):
             ext = splitext(bag)[-1]
             if ext in ['.tgz', '.gz']:
                 bags = join(src, bag)
-        return bags_list[0]
+        return bag
 
     def unpack_rename(self, bag_path, tmp):
         """Unpacks tarfile to a new directory with the name of the bag identifier (a UUID)"""

--- a/package_bag/routines.py
+++ b/package_bag/routines.py
@@ -44,7 +44,7 @@ class BagDiscoverer(object):
 
     def discover_next_bag(self, src):
         """Looks in a given directory for compressed bags, adds to list to process"""
-        bags_list = []
+        bag = None
         for bag in listdir(src):
             ext = splitext(bag)[-1]
             if ext in ['.tgz', '.gz']:

--- a/package_bag/routines.py
+++ b/package_bag/routines.py
@@ -48,7 +48,7 @@ class BagDiscoverer(object):
         for bag in listdir(src):
             ext = splitext(bag)[-1]
             if ext in ['.tgz', '.gz']:
-                bags_list.append(join(src, bag))
+                bags = join(src, bag)
         return bags_list[0]
 
     def unpack_rename(self, bag_path, tmp):

--- a/package_bag/routines.py
+++ b/package_bag/routines.py
@@ -24,7 +24,6 @@ class BagDiscoverer(object):
         try:
             bag = self.discover_next_bag(settings.SRC_DIR)
             if bag:
-                print(bag)
                 try:
                     bag_id = self.unpack_rename(bag, settings.TMP_DIR)
                     bag_path = join(settings.TMP_DIR, bag_id)
@@ -44,8 +43,8 @@ class BagDiscoverer(object):
             print(e)
         # what does this process bags function return? - you want to return something out of the view that indicates which objects were processed
         # e.g.: "{} bags discovered".format(len(processed)), processed
-        msg = "Bags discovered." if bag else "No bags were found."
-        return msg
+        msg = "Bag discovered." if bag else "No bags were found."
+        return msg, bag_id if bag else msg
 
     def discover_next_bag(self, src):
         """Looks in a given directory for compressed bags, adds to list to process"""

--- a/package_bag/routines.py
+++ b/package_bag/routines.py
@@ -21,7 +21,7 @@ class BagDiscoverer(object):
     """
 
     def run(self):
-        bag = self.discover_bags(settings.SRC_DIR)[0]
+        bag = self.discover_next_bag(settings.SRC_DIR)
         try:
             bag_id = self.unpack_rename(bag, settings.TMP_DIR)
             bag_path = join(settings.TMP_DIR, bag_id)
@@ -40,16 +40,16 @@ class BagDiscoverer(object):
         # what does this process bags function return? - you want to return something out of the view that indicates which objects were processed
         # e.g.: "{} bags discovered".format(len(processed)), processed
         msg = "Bags discovered." if bag else "No bags were found."
-        return msg, bag
+        return msg, bag_id
 
-    def discover_bags(self, src):
+    def discover_next_bag(self, src):
         """Looks in a given directory for compressed bags, adds to list to process"""
         bags_list = []
         for bag in listdir(src):
             ext = splitext(bag)[-1]
             if ext in ['.tgz', '.gz']:
                 bags_list.append(join(src, bag))
-        return bags_list
+        return bags_list[0]
 
     def unpack_rename(self, bag_path, tmp):
         """Unpacks tarfile to a new directory with the name of the bag identifier (a UUID)"""

--- a/package_bag/tests.py
+++ b/package_bag/tests.py
@@ -74,7 +74,6 @@ class TestPackage(TestCase):
             discover = BagDiscoverer().run()
             count += 1
         self.assertIsNot(False, discover)
-        self.assertEqual(len(discover), expected, "Wrong number of bags processed.")
         self.assertEqual(len(Bag.objects.all()), expected, "Wrong number of bags saved in database.")
         self.assertEqual(len(listdir(settings.TMP_DIR)), expected, "Invalid bags were not deleted.")
 

--- a/package_bag/tests.py
+++ b/package_bag/tests.py
@@ -74,6 +74,7 @@ class TestPackage(TestCase):
             discover = BagDiscoverer().run()
             count += 1
         self.assertIsNot(False, discover)
+        print(discover)
         self.assertEqual(len(Bag.objects.all()), expected, "Wrong number of bags saved in database.")
         self.assertEqual(len(listdir(settings.TMP_DIR)), expected, "Invalid bags were not deleted.")
 

--- a/package_bag/tests.py
+++ b/package_bag/tests.py
@@ -70,11 +70,11 @@ class TestPackage(TestCase):
         shutil.rmtree(settings.SRC_DIR)
         shutil.copytree(BAG_FIXTURE_DIR, settings.SRC_DIR)
         count = 0
-        while count < total_bags:
+        while count < (total_bags + 1):
             discover = BagDiscoverer().run()
             count += 1
-        self.assertIsNot(False, discover)
-        print(discover)
+        self.assertTrue(isinstance(discover, tuple))
+        self.assertTupleEqual(discover, ('No bags were found.', None), "Incorrect response when no bags are found.")
         self.assertEqual(len(Bag.objects.all()), expected, "Wrong number of bags saved in database.")
         self.assertEqual(len(listdir(settings.TMP_DIR)), expected, "Invalid bags were not deleted.")
 

--- a/package_bag/tests.py
+++ b/package_bag/tests.py
@@ -65,10 +65,14 @@ class TestPackage(TestCase):
 
     def test_discover_bags(self):
         """Ensures that bags are correctly discovered."""
+        total_bags = len([i for i in listdir(BAG_FIXTURE_DIR)])
         expected = len([i for i in listdir(BAG_FIXTURE_DIR) if not i.startswith("invalid_")])
         shutil.rmtree(settings.SRC_DIR)
         shutil.copytree(BAG_FIXTURE_DIR, settings.SRC_DIR)
-        discover = BagDiscoverer().run()
+        count = 0
+        while count < total_bags:
+            discover = BagDiscoverer().run()
+            count += 1
         self.assertIsNot(False, discover)
         self.assertEqual(len(discover), expected, "Wrong number of bags processed.")
         self.assertEqual(len(Bag.objects.all()), expected, "Wrong number of bags saved in database.")


### PR DESCRIPTION
I've (inelegantly) modified the BagDiscoverer routine so that it processes one bag at a time, and modified the associated test so that it passes. However, the associated view is now failing. I think what's happening is that the view (which is from asterism) is expecting a list, which it's not getting. Should I return something different in the routine, or should I use a different view?