### PR TITLE
Update bag model field names

### DIFF
--- a/package_bag/routines.py
+++ b/package_bag/routines.py
@@ -163,9 +163,9 @@ class PackageDeliverer(object):
         r = post(
             url,
             json={
-                "bag_data": bag_data,
+                "data": bag_data,
                 "origin": bag.origin,
-                "identifier": bag.bag_identifier},
+                "bag_identifier": bag.bag_identifier},
             headers={
                 "Content-Type": "application/json"},
         )


### PR DESCRIPTION
Fixes #68.

Note that POST requests to Ursa Major will still fail until RockefellerArchiveCenter/ursa_major#137 is fixed.